### PR TITLE
Change ddate availability

### DIFF
--- a/ddate.1
+++ b/ddate.1
@@ -110,5 +110,4 @@ Malaclypse the Younger,
 .I "Principia Discordia, Or How I Found Goddess And What I Did To Her When I Found Her"
 
 .SH AVAILABILITY
-The ddate command is part of the util-linux package and is available from
-ftp://ftp.kernel.org/pub/linux/utils/util-linux/.
+The ddate command is available from https://github.com/bo0ts/ddate.


### PR DESCRIPTION
Just updated the ddate URL from ftp.kernel.org to your repo: https://github.com/bo0ts/ddate
