### PR TITLE
Correct the "source" text in manpage title line

### DIFF
--- a/ddate.1
+++ b/ddate.1
@@ -1,6 +1,6 @@
 .\" All Rites Reversed.  This file is in the PUBLIC DOMAIN.
 .\" Kallisti.
-.TH DDATE 1 "Bureaucracy 3161" "util-linux" "Emperor Norton User Command"
+.TH DDATE 1 "Bureaucracy 3161" "ddate" "Emperor Norton User Command"
 .SH NAME
 ddate \- convert Gregorian dates to Discordian dates
 .SH SYNOPSIS


### PR DESCRIPTION
ddate is no longer packaged by util-linux.
