### PR TITLE
removed unneccessary locale code

### DIFF
--- a/ddate.c
+++ b/ddate.c
@@ -31,6 +31,11 @@
 
    2000-03-17 Burt Holzman <holzman+ddate@gmail.com>
    - added range checks for dates
+
+   2014-06-07 William Woodruff <william@tuffbizz.com>
+   - removed gettext dependent locale code
+
+   FIVE TONS OF FLAX
 */
 
 /* configuration options  VVVVV   READ THIS!!! */
@@ -61,12 +66,6 @@
 #include <string.h>
 #include <time.h>
 #include <stdio.h>
-
-// work around includes and defines from formerly nls.h
-#include <locale.h>
-#include <libintl.h>
-
-#define LOCALEDIR "/usr/share/locale"
 
 
 // work around includes and defines from formerly c.h
@@ -184,10 +183,6 @@ main (int argc, char *argv[]) {
     progname = argv[0];
     if ((p = strrchr(progname, '/')) != NULL)
 	progname = p+1;
-
-    setlocale(LC_ALL, "");
-    bindtextdomain(PACKAGE, LOCALEDIR);
-    textdomain(PACKAGE);
 
     srandom(time(NULL));
     /* do args here */


### PR DESCRIPTION
Hi there.

I was going through ddate.c, and I noticed that the locale includes and checks weren't really doing anything towards the functionality of the program. Furthermore, they were causing the build to fail on OS X (libintl.h isn't part of BSD's gettext). 

Just thought I could help to improve portability.
If the locale calls are performing some important check that I'm not aware of, please reject this pull. 

woodruffw
