### PR TITLE
Fix segfault of the architectures where sizeof(long) != sizeof(time_t)

### DIFF
--- a/ddate.c
+++ b/ddate.c
@@ -183,7 +183,7 @@ struct disc_time makeday(int,int,int);
 
 int
 main (int argc, char *argv[]) {
-    long t;
+    time_t t;
     struct tm *eris;
     int bob,raw;
     struct disc_time hastur;


### PR DESCRIPTION
The program segfaults because of incorrectly defined time type. In x86-x32 architecture sizeof(time_t) = 64, when sizeof(long) is only 32.