### PR TITLE
'%Y' added to man page

### DIFF
--- a/ddate.1
+++ b/ddate.1
@@ -47,6 +47,8 @@ Tab
 .IP %X
 Number of days remaining until X-Day. (Not valid if the SubGenius options
 are not compiled in.)
+.IP %Y
+The year of our Lady Discord (i.e., 3182)
 .IP %{
 .IP %}
 Used to enclose the part of the string which is to be replaced with the


### PR DESCRIPTION
The description for %Y is missing in the current man page. It is there in the examples but not in the list of string format mechanisms.