### PR TITLE
Removing some unused code / fixing possible ARRAY_SIZE issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 ddate.exe
 ddate.obj
+.vscode/

--- a/ddate.c
+++ b/ddate.c
@@ -84,10 +84,6 @@
 #define PACKAGE "ddate"
 #define PACKAGE_STRING "Stand Alone"
 
-#ifndef __GNUC__
-#define inline /* foo */
-#endif
-
 #ifdef KILL_BOB
 int xday_countdown(int yday, int year);
 #endif
@@ -153,16 +149,16 @@ default_fmt
 
 #define DY(y) (y+1166)
 
-static inline char *ending(int i) {
+static char *ending(int i) {
 	return i/10==1?"th":(i%10==1?"st":(i%10==2?"nd":(i%10==3?"rd":"th")));
 }
 
-static inline int leapp(int i) {
+static int leapp(int i) {
 	return (!(DY(i)%4))&&((DY(i)%100)||(!(DY(i)%400)));
 }
 
 /* select a random string */
-static inline char *sel(char **strings, int num) {
+static char *sel(char **strings, int num) {
 	return(strings[rand()%num]);
 }
 

--- a/ddate.c
+++ b/ddate.c
@@ -76,16 +76,9 @@
 #include <stdio.h>
 
 
-// work around includes and defines from formerly c.h
 #ifndef ARRAY_SIZE
 #define ARRAY_SIZE(arr) (sizeof (arr) / sizeof (arr)[0])
 #endif
-
-/* &a[0] degrades to a pointer: a different type from an array */
-# define __must_be_array(a) \
-	BUILD_BUG_ON_ZERO(__builtin_types_compatible_p(__typeof__(a), __typeof__(&a[0])))
-
-#define BUILD_BUG_ON_ZERO(e) (sizeof(struct { int:-!!(e); }))
 
 /* work around hacks for standalone package */
 #define PACKAGE "ddate"
@@ -173,10 +166,7 @@ static inline char *sel(char **strings, int num) {
 	return(strings[rand()%num]);
 }
 
-void print(struct disc_time,char **); /* old */
 void format(char *buf, const char* fmt, struct disc_time dt);
-/* read a fortune file */
-int load_fortunes(char *fn, char *delim, char** result);
 
 struct disc_time convert(int,int);
 struct disc_time makeday(int,int,int);

--- a/ddate.c
+++ b/ddate.c
@@ -78,7 +78,7 @@
 
 // work around includes and defines from formerly c.h
 #ifndef ARRAY_SIZE
-# define ARRAY_SIZE(arr) (sizeof(arr) / sizeof(arr[0]))
+#define ARRAY_SIZE(arr) (sizeof (arr) / sizeof (arr)[0])
 #endif
 
 /* &a[0] degrades to a pointer: a different type from an array */


### PR DESCRIPTION
I looked over my last pull request once I noticed it had been merged. I did a deep dive into what the existing code was there for -- the last time I used C heavily was over a decade ago.  I fixed an unlikely but possible future edge case error in the ARRAY_SIZE macro.  I also removed some code that was no longer used or needed.

The rationale for removing the inline can be summarized at: https://stackoverflow.com/questions/7762731/whats-the-difference-between-static-and-static-inline-function.  This retains compatibility with older compilers while very slightly reducing complexity.