### PR TITLE
Fix aneristic date formatting (M-D/D-M)

### DIFF
--- a/ddate.c
+++ b/ddate.c
@@ -201,9 +201,9 @@ main (int argc, char *argv[]) {
 	int moe=atoi(argv[pi]), larry=atoi(argv[pi+1]), curly=atoi(argv[pi+2]);
 	hastur=makeday(
 #ifdef US_FORMAT
-	    moe,larry,
-#else
 	    larry,moe,
+#else
+	    moe,larry,
 #endif
 	    curly);
 	if (hastur.season == -1) {


### PR DESCRIPTION
I guess this might have been done intentionally as a joke, but ddate uses US format (M-D-Y) by default rather than Commonwealth (D-M-Y). Thus uncommenting #define US_FORMAT puts it into Commonwealth format.

This commit changes the behavior so it is Commonwealth by default and the US_FORMAT flag works as advertised. But am I fixing a bug, or removing a feature?